### PR TITLE
feat: add UI to change resolution scaling in multiples of .25 to 2x

### DIFF
--- a/XIVWindowResizer/Configuration.cs
+++ b/XIVWindowResizer/Configuration.cs
@@ -1,0 +1,9 @@
+using Dalamud.Configuration;
+
+namespace XIVWindowResizer;
+
+public class Configuration : IPluginConfiguration
+{
+    public int Version { get; set; } = 0;
+    public bool OpenAutomaticallyInGPose { get; set; } = true;
+}

--- a/XIVWindowResizer/Plugin.cs
+++ b/XIVWindowResizer/Plugin.cs
@@ -2,10 +2,12 @@ using Dalamud.Game.Command;
 using Dalamud.IoC;
 using Dalamud.Plugin;
 using XIVWindowResizer.Helpers;
+using XIVWindowResizer.UI;
 using System.Drawing;
 using Dalamud.Game.Text;
 using System;
 using Dalamud.Plugin.Services;
+using Dalamud.Interface.Windowing;
 
 namespace XIVWindowResizer;
 
@@ -20,23 +22,65 @@ public sealed class Plugin : IDalamudPlugin
     [PluginService]
     private IChatGui _chatGui { get; init; }
 
+    [PluginService]
+    private IClientState _clientState { get; init; }
+
+    [PluginService]
+    private IFramework _framework { get; init; }
+
+    [PluginService]
+    private IDalamudPluginInterface _pluginInterface { get; init; }
+
+    private bool _lastGposeState;
+
     private Size _originalWindowSize { get; set; }
 
     private WindowSizeHelper _windowSizeHelper { get; init; }
+
+    private readonly WindowSystem _windowSystem = new("XIVWindowResizer");
+    private GPoseResizerWindow _gposeWindow;
+    private Configuration _config;
 
     public Plugin()
     {
         _windowSizeHelper = new WindowSizeHelper(new WindowSearchHelper());
         _originalWindowSize = _windowSizeHelper.GetWindowSize();
 
+        _config = _pluginInterface.GetPluginConfig() as Configuration ?? new Configuration();
+
         _commandManager.AddHandler(CommandName, new CommandInfo(OnCommand)
         {
-            HelpMessage = "Set window size.\r\nUsage:\r\n/wresize set <width> <height> - Set window size.\r\n/wresize reset - Reset window size back to the original size.\r\n/wresize update - Update window size used by /wresize reset command. Use if you have changed game's screen resolution without restarting the game or reloading the plugin."
+            HelpMessage = "Window resizer.\r\nUsage:\r\n/wresize - Toggle the resizer window.\r\n/wresize set <width> <height> - Set window size.\r\n/wresize reset - Reset window size back to the original size.\r\n/wresize update - Update window size used by /wresize reset command. Use if you have changed game's screen resolution without restarting the game or reloading the plugin."
         });
+
+        _gposeWindow = new GPoseResizerWindow(_windowSizeHelper, () => _originalWindowSize, _config, () => _pluginInterface.SavePluginConfig(_config));
+        _lastGposeState = _clientState.IsGPosing;
+        _gposeWindow.IsOpen = _lastGposeState && _config.OpenAutomaticallyInGPose;
+        _windowSystem.AddWindow(_gposeWindow);
+
+        _pluginInterface.UiBuilder.Draw += _windowSystem.Draw;
+        _pluginInterface.UiBuilder.OpenMainUi += OnOpenMainUi;
+        _pluginInterface.UiBuilder.DisableGposeUiHide = true;
+
+        _framework.Update += OnFrameworkUpdate;
     }
+
+    private void OnFrameworkUpdate(IFramework framework)
+    {
+        bool current = _clientState.IsGPosing;
+        if (current && !_lastGposeState && _config.OpenAutomaticallyInGPose)
+            _gposeWindow.IsOpen = true;
+        _lastGposeState = current;
+    }
+
+    private void OnOpenMainUi() => _gposeWindow.IsOpen = true;
 
     public void Dispose()
     {
+        _framework.Update -= OnFrameworkUpdate;
+        _pluginInterface.UiBuilder.OpenMainUi -= OnOpenMainUi;
+        _pluginInterface.UiBuilder.Draw -= _windowSystem.Draw;
+        _windowSystem.RemoveAllWindows();
         _commandManager.RemoveHandler(CommandName);
     }
 
@@ -45,6 +89,9 @@ public sealed class Plugin : IDalamudPlugin
         string[] splitArgs = args.ToLowerInvariant().Split(' ');
         switch(splitArgs[0])
         {
+            case "":
+                _gposeWindow.IsOpen = !_gposeWindow.IsOpen;
+                break;
             case "set":
                 int width = 0;
                 int height = 0;

--- a/XIVWindowResizer/Plugin.cs
+++ b/XIVWindowResizer/Plugin.cs
@@ -38,7 +38,9 @@ public sealed class Plugin : IDalamudPlugin
     private WindowSizeHelper _windowSizeHelper { get; init; }
 
     private readonly WindowSystem _windowSystem = new("XIVWindowResizer");
+
     private GPoseResizerWindow _gposeWindow;
+    
     private Configuration _config;
 
     public Plugin()

--- a/XIVWindowResizer/UI/GPoseResizerWindow.cs
+++ b/XIVWindowResizer/UI/GPoseResizerWindow.cs
@@ -12,12 +12,10 @@ public class GPoseResizerWindow : Window
 {
     private static readonly float[] Scales = { 1.00f, 1.25f, 1.50f, 1.75f, 2.00f };
     private static readonly string[] ScaleLabels = { "1.00x", "1.25x", "1.50x", "1.75x", "2.00x" };
-
     private readonly WindowSizeHelper _windowSizeHelper;
     private readonly Func<Size> _getOriginalSize;
     private readonly Configuration _config;
     private readonly Action _saveConfig;
-
     private int _selectedScale = 0;
 
     public GPoseResizerWindow(
@@ -44,6 +42,7 @@ public class GPoseResizerWindow : Window
 
     public override void Draw()
     {
+        _selectedScale = MatchCurrentScale();
         ImGui.SetNextItemWidth(80f);
         if (ImGui.Combo("##scale", ref _selectedScale, ScaleLabels, ScaleLabels.Length))
         {
@@ -71,5 +70,19 @@ public class GPoseResizerWindow : Window
         int w = (int)Math.Round(orig.Width * scale);
         int h = (int)Math.Round(orig.Height * scale);
         _windowSizeHelper.SetWindowSize(w, h);
+    }
+
+    private int MatchCurrentScale()
+    {
+        var orig = _getOriginalSize();
+        var current = _windowSizeHelper.GetWindowSize();
+        for (int i = 0; i < Scales.Length; i++)
+        {
+            int w = (int)Math.Round(orig.Width * Scales[i]);
+            int h = (int)Math.Round(orig.Height * Scales[i]);
+            if (w == current.Width && h == current.Height)
+                return i;
+        }
+        return -1;
     }
 }

--- a/XIVWindowResizer/UI/GPoseResizerWindow.cs
+++ b/XIVWindowResizer/UI/GPoseResizerWindow.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Drawing;
+using System.Numerics;
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Utility;
+using Dalamud.Interface.Windowing;
+using XIVWindowResizer.Helpers;
+
+namespace XIVWindowResizer.UI;
+
+public class GPoseResizerWindow : Window
+{
+    private static readonly float[] Scales = { 1.00f, 1.25f, 1.50f, 1.75f, 2.00f };
+    private static readonly string[] ScaleLabels = { "1.00x", "1.25x", "1.50x", "1.75x", "2.00x" };
+
+    private readonly WindowSizeHelper _windowSizeHelper;
+    private readonly Func<Size> _getOriginalSize;
+    private readonly Configuration _config;
+    private readonly Action _saveConfig;
+
+    private int _selectedScale = 0;
+
+    public GPoseResizerWindow(
+        WindowSizeHelper windowSizeHelper,
+        Func<Size> getOriginalSize,
+        Configuration config,
+        Action saveConfig)
+        : base("XIVWindowResizer###xivwindowresizer_gpose",
+            ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoResize |
+            ImGuiWindowFlags.NoScrollbar |
+            ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoBringToFrontOnFocus)
+    {
+        _windowSizeHelper = windowSizeHelper;
+        _getOriginalSize = getOriginalSize;
+        _config = config;
+        _saveConfig = saveConfig;
+    }
+
+    public override void PreDraw()
+    {
+        base.PreDraw();
+        Position = new Vector2(20f, 20f) * ImGuiHelpers.GlobalScale;
+        PositionCondition = ImGuiCond.FirstUseEver;
+    }
+
+    public override void Draw()
+    {
+        ImGui.SetNextItemWidth(80f);
+        if (ImGui.Combo("##scale", ref _selectedScale, ScaleLabels, ScaleLabels.Length))
+        {
+            ApplyScale(Scales[_selectedScale]);
+        }
+
+        ImGui.SameLine();
+        if (ImGui.Button("Reset"))
+        {
+            _selectedScale = 0;
+            ApplyScale(Scales[0]);
+        }
+
+        bool openAuto = _config.OpenAutomaticallyInGPose;
+        if (ImGui.Checkbox("Open automatically in GPose", ref openAuto))
+        {
+            _config.OpenAutomaticallyInGPose = openAuto;
+            _saveConfig();
+        }
+    }
+
+    private void ApplyScale(float scale)
+    {
+        var orig = _getOriginalSize();
+        int w = (int)Math.Round(orig.Width * scale);
+        int h = (int)Math.Round(orig.Height * scale);
+        _windowSizeHelper.SetWindowSize(w, h);
+    }
+}

--- a/XIVWindowResizer/UI/GPoseResizerWindow.cs
+++ b/XIVWindowResizer/UI/GPoseResizerWindow.cs
@@ -27,8 +27,7 @@ public class GPoseResizerWindow : Window
         Action saveConfig)
         : base("XIVWindowResizer###xivwindowresizer_gpose",
             ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoResize |
-            ImGuiWindowFlags.NoScrollbar |
-            ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoBringToFrontOnFocus)
+            ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.AlwaysAutoResize)
     {
         _windowSizeHelper = windowSizeHelper;
         _getOriginalSize = getOriginalSize;


### PR DESCRIPTION
This addresses issue #16

Primary feature is the ability to resize the window by a UI window, openable by /wresize or by having the configuration behave so that said window automatically opens when in gpose, scaling goes from 1x to 2x in 0.25 increments, window spawns 20 by 20 pixels form top left corner. Simple checkbox to open automatically in gpose or not, reset and change resolution scaling combobox. 

PR adds one plugin configuration to change if the window opens, a window and some bootstrapping for it. If you have any questions or thoughts please let me know!